### PR TITLE
Fix bug in isdash

### DIFF
--- a/src/DocOpt.jl
+++ b/src/DocOpt.jl
@@ -543,13 +543,7 @@ function parse_seq(tokens, options)
     result
 end
 
-function isdash(token)
-    if token == '-' || token == "--"
-        true
-    else
-        false
-    end
-end
+isdash(token) = token == "-" || token == "--"
 
 function parse_atom(tokens, options)
     """atom ::= '(' expr ')' | '[' expr ']' | 'options'


### PR DESCRIPTION
The way isdashed is used, the comparison token=='-' would always test false since token is a String and '-' is a Char and they could never compare equal to each other in Julia.
