### PR TITLE
use standard form of the license filename

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2014 Vladimir Keleshev, <vladimir@keleshev.com>
                    Kenta Sato, <bicycle1885@gmail.com>
 


### PR DESCRIPTION
Include title in the license text, as is standard practice (e.g. http://choosealicense.com/licenses/mit/)

This change also allows the package's license to be recognized in http://packages.julialang.org.