### PR TITLE
Fix method overwrite warnings in julia master (v0.5-dev)

### DIFF
--- a/src/DocOpt.jl
+++ b/src/DocOpt.jl
@@ -200,20 +200,6 @@ function patternmatch(pattern::(@compat Union{Optional,OptionsShortcut}), left, 
     return true, left, collected
 end
 
-function patternmatch(pattern::Either, left, collected=Pattern[])
-    outcomes = Any[]
-    for pat in pattern.children
-        matched, _, _ = outcome = patternmatch(pat, left, collected)
-        if matched
-            push!(outcomes, outcome)
-        end
-    end
-    if !isempty(outcomes)
-        return reduce((x, y) -> length(x[2]) < length(y[2]), outcomes[1], outcomes[2:end])
-    end
-    return false, left, collected
-end
-
 function patternmatch(pattern::Required, left, collected=Pattern[])
     l = left
     c = collected


### PR DESCRIPTION
This is caused by the fact that `patternmatch(Either, Any, Any)` was defined twice actually.

The exact warnings I saw are as follows:

```
WARNING: Method definition patternmatch(DocOpt.Either, Any) in module DocOpt at /Users/ryuyamamoto/.julia/v0.5/DocOpt/src/DocOpt.jl:204 overwritten at /Users/ryuyamamoto/.julia/v0.5/DocOpt/src/DocOpt.jl:230.
WARNING: Method definition patternmatch(DocOpt.Either, Any, Any) in module DocOpt at /Users/ryuyamamoto/.julia/v0.5/DocOpt/src/DocOpt.jl:204 overwritten at /Users/ryuyamamoto/.julia/v0.5/DocOpt/src/DocOpt.jl:230.
```

Verified that tests passing on v0.4.0 and current Julia master locally. 

NOTE: to be honest, I didn't understand the implementation details of `patternmatch`, but I believe this fixes should be right as far as I understand the warnings correctly. 