### PR TITLE
add a precompile workload 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,15 @@
 name = "DocOpt"
 uuid = "968ba79b-81e4-546f-ab3a-2eecfa62a9db"
-version = "0.5"
+version = "0.5.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 
 [compat]
 julia = "1.3"
+SnoopPrecompile = "1.0.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/DocOpt.jl
+++ b/src/DocOpt.jl
@@ -22,10 +22,12 @@ end
 struct DocOptLanguageError <: Exception
     msg::AbstractString
 end
+Base.showerror(io::IO, e::DocOptLanguageError) = print(io, "DocOptLanguageError: ", e.usage)
 
 struct DocOptExit <: Exception
     usage::AbstractString
 end
+Base.showerror(io::IO, e::DocOptExit) = print(io, "DocOptExit: ", e.usage)
 
 abstract type Pattern end
 abstract type LeafPattern <: Pattern end

--- a/src/DocOpt.jl
+++ b/src/DocOpt.jl
@@ -606,4 +606,30 @@ function docopt(doc::AbstractString,
     end
 end
 
+using SnoopPrecompile
+
+@precompile_setup begin
+    doc = """Naval Fate.
+
+    Usage:
+      naval_fate.jl ship new <name>...
+      naval_fate.jl ship <name> move <x> <y> [--speed=<kn>]
+      naval_fate.jl ship shoot <x> <y>
+      naval_fate.jl mine (set|remove) <x> <y> [--moored|--drifting]
+      naval_fate.jl -h | --help
+      naval_fate.jl --version
+
+    Options:
+      -h --help     Show this screen.
+      --version     Show version.
+      --speed=<kn>  Speed in knots [default: 10].
+      --moored      Moored (anchored) mine.
+      --drifting    Drifting mine.
+
+    """
+    @precompile_all_calls begin
+        docopt(doc, ["ship", "new", "BoatyMcBoatFace"]; version=v"2.0.0")
+    end
+end
+
 end  # DocOpt

--- a/src/DocOpt.jl
+++ b/src/DocOpt.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module DocOpt
 
 export docopt


### PR DESCRIPTION
I came across this package and thought it was kind of slow to use so I added a small precompile workload to speed it up:

```
# Before:
# 1.8: 2.83s
# 1.9: 2.63s

# After:
# 1.8: 2.18s
# 1.9: 0.48s
```

It feels like this should be even better though.